### PR TITLE
fix compatibility with fasthttprouter

### DIFF
--- a/server.go
+++ b/server.go
@@ -357,7 +357,7 @@ func startFasthttp() {
 }
 
 //fasthttprouter
-func fastHttpHandler(ctx *fasthttp.RequestCtx, ps fasthttprouter.Params) {
+func fastHttpHandler(ctx *fasthttp.RequestCtx) {
 	if sleepTime > 0 {
 		time.Sleep(sleepTimeDuration)
 	}


### PR DESCRIPTION
I relased `fasthttprouter` v0.1 and remove the `Params` struct now.

This PR is fix compatibility with these changes.
