### PR TITLE
Actualized test `Bxog`

### DIFF
--- a/server.go
+++ b/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/astaxie/beego/context"
 	"github.com/bmizerany/pat"
 	"github.com/buaazp/fasthttprouter"
+	"github.com/claygod/Bxog"
 	"github.com/dimfeld/httptreemux"
 	"github.com/dinever/golf"
 	"github.com/emicklei/go-restful"
@@ -104,8 +105,8 @@ func main() {
 		startBeego()
 	case "bone":
 		startBone()
-	// case "bxog":
-	// 	startBxog()
+	case "bxog":
+	 	startBxog()
 	case "chi":
 		startChi()
 	case "denco":
@@ -233,18 +234,18 @@ func startBone() {
 	http.ListenAndServe(":"+strconv.Itoa(port), mux)
 }
 
-// // bxog
-// func bxogHandler(w http.ResponseWriter, req *http.Request, r *bxog.Router) {
-// 	if sleepTime > 0 {
-// 		time.Sleep(sleepTimeDuration)
-// 	}
-// 	w.Write(message)
-// }
-// func startBxog() {
-// 	mux := bxog.New()
-// 	mux.Add("/hello", bxogHandler)
-// 	mux.Start(":" + strconv.Itoa(port))
-// }
+// bxog
+func bxogHandler(w http.ResponseWriter, req *http.Request) {
+ 	if sleepTime > 0 {
+ 		time.Sleep(sleepTimeDuration)
+ 	}
+ 	w.Write(message)
+}
+ func startBxog() {
+ 	mux := bxog.New()
+ 	mux.Add("/hello", bxogHandler)
+ 	mux.Start(":" + strconv.Itoa(port))
+ }
 
 //chi
 func startChi() {


### PR DESCRIPTION
Tests on the router `Bxog` does not work, because the router is now in the parameters are passed through the query context. It certainly reduced the speed of the router, but the increased ease of use.

Also, you may be interesting to add to the test version of the router `Door` (https://github.com/claygod/door) and operating under `Fast HTTP server`?