### PR TITLE
Changing the mode of transmission in the Bxog

### DIFF
--- a/server.go
+++ b/server.go
@@ -231,11 +231,11 @@ func startBone() {
 }
 
 // bxog
-func bxogHandler(w http.ResponseWriter, req *http.Request) {
+func bxogHandler(w http.ResponseWriter, req *http.Request, r *bxog.Router) {
 	if sleepTime > 0 {
 		time.Sleep(sleepTimeDuration)
 	}
-	w.Write(message)
+	io.WriteString(w, message)
 }
 func startBxog() {
 	mux := bxog.New()


### PR DESCRIPTION
To increase the speed parameters are transmitted via a context.