### PR TITLE
fixed gear’s bench

### DIFF
--- a/server.go
+++ b/server.go
@@ -342,6 +342,7 @@ func startGear() {
 		}
 		return c.HTML(200, messageStr)
 	})
+	app.UseHandler(router)
 	app.Listen(":" + strconv.Itoa(port))
 }
 


### PR DESCRIPTION
非常感谢你的评测，我发现 Gear 的测试逻辑不对，所以导致很多 bench 图表一枝独秀。

Gear 的 Router 也是一个的 Gear 中间件， 不会默认挂载，这里修复了一下。

目前的 Gear 版本 handle 了 `context canceled` error, 回头修复。

另外，按照目前的测试逻辑——简单的回写一个 `hello`，基于原生 http server 的框架区别不会很大，无非就是多了一个初始化逻辑。我本地对比跑了一下 gin 和 gear，gear 稍低一点。因为 Gear 内置的初始化逻辑确实多了一些，包括检测 Compress 组件、recover 异常、初始化 cookie 模块、初始化 context 等