### PR TITLE
Set production environment for Gramework.

### DIFF
--- a/server.go
+++ b/server.go
@@ -623,6 +623,7 @@ func grameworkHandler(ctx *gramework.Context) {
 }
 
 func startGramework() {
+	gramework.SetEnv(gramework.PROD) // equivalent of ENV=prod
 	app := gramework.New()
 	app.GET("/hello", grameworkHandler)
 	app.ListenAndServe(":" + strconv.Itoa(port))


### PR DESCRIPTION
Development environments (such as DEV and STAGE) have more logging output and debug features, that should be disabled in production.